### PR TITLE
fix(register): remove required property on param

### DIFF
--- a/frontend/src/app/auth/register/register.component.html
+++ b/frontend/src/app/auth/register/register.component.html
@@ -309,7 +309,6 @@
                             class="form-control rounded-0"
                             [(ngModel)]="user.linked_relay_id"
                             #linked_relay_id="ngModel"
-                            required
                         >
                             <option value=""></option>
                             <option value="0">Aucun</option>


### PR DESCRIPTION
During account creation, this optional field was tagged as required and prevented account creation unless specified